### PR TITLE
fix:ports for each service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,12 @@
 services:
   model-service:
     build: ../model-service
+    ports:
+      - 8081:5000
   app-service:
     build: ../app-service
-    environment:
-      - MODEL_SERVICE_URL="model-service"
+    ports:
+      - 8082:5000
   frontend:
     build: ../app-frontend
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,9 @@ services:
     build: ../app-service
     ports:
       - 8082:5000
+    environment:
+      - MODEL_SERVICE_URL="model-service"
+      - MODEL_SERVICE_PORT="8081"
   frontend:
     build: ../app-frontend
     ports:


### PR DESCRIPTION
added ports for each service. app-service api reachable on http://localhost:8082/apidocs/, model-service reachable on http://localhost:8081/apidocs/.
added environment variable placeholder, still broken