### PR TITLE
feat: A2 - Install Istio through istioctl

### DIFF
--- a/provisioning/finalization.yml
+++ b/provisioning/finalization.yml
@@ -292,88 +292,26 @@
       backrefs: yes
     when: not path_contents|regex_search('istio-1.25.2')
 
+  - name: Check if istio namespace already existed (step 23)
+    kubernetes.core.k8s_info:
+      kubeconfig: "{{ kubeconfig }}"
+      kind: Namespace
+      name: istio-system
+    register: istio_system_ns_info
+    ignore_errors: true
+
   - name: Copy Istio configuration file to node (step 23)
     copy:
       src: "{{ playbook_dir }}/istio-config.yml"
       dest: /tmp/istio-config.yml
       mode: '0644'
+    when: istio_system_ns_info.resources | length == 0
 
   - name: Run istio installation on controller node (step 23)
-    command: istioctl install -f /tmp/istio-config.yml
-    when: ansible_hostname == 'controller'
-
-#  - name: Add Istio Helm repository (step 23)
-#    kubernetes.core.helm_repository:
-#      name: istio
-#      repo_url: https://istio-release.storage.googleapis.com/charts
-#      kubeconfig: "{{ kubeconfig }}"
-#
-#  - name: Create namespace istio-system (step 23)
-#    kubernetes.core.k8s:
-#      kubeconfig: "{{ kubeconfig }}"
-#      state: present
-#      definition:
-#        apiVersion: v1
-#        kind: Namespace
-#        metadata:
-#          name: istio-system
-#
-#  - name: Install Istio base chart (CRDs) (step 23)
-#    kubernetes.core.helm:
-#      release_name: istio-base
-#      chart_ref: istio/base
-#      chart_version: "1.25.2"
-#      release_namespace: istio-system
-#      create_namespace: false
-#      kubeconfig: "{{ kubeconfig }}"
-#      wait: true
-#
-#  - name: Install Istio control plane (istiod) (step 23)
-#    kubernetes.core.helm:
-#      release_name: istiod
-#      chart_ref: istio/istiod
-#      chart_version: "1.25.2"
-#      release_namespace: istio-system
-#      create_namespace: false
-#      kubeconfig: "{{ kubeconfig }}"
-#      wait: true
-#      timeout: "300s"
-#      values:
-#        pilot:
-#          resources:
-#            # shrink requests so istiod can schedule on low‐RAM nodes (too heave otherwise, might need to be changed in the future)
-#            requests:
-#              cpu: "100m"
-#              memory: "128Mi"
-#            limits:
-#              cpu: "200m"
-#              memory: "256Mi"
-#
-#  - name: Deploy Istio ingress gateway with fixed IP (step 23)
-#    kubernetes.core.helm:
-#      release_name: istio-ingress
-#      chart_ref: istio/gateway
-#      chart_version: "1.25.2"
-#      release_namespace: istio-system
-#      create_namespace: false
-#      kubeconfig: "{{ kubeconfig }}"
-#      wait: true
-#      timeout: "300s"
-#      values:
-#        gateways:
-#          istio-ingressgateway:
-#            enabled: true
-#            service:
-#              type: LoadBalancer
-#              loadBalancerIP: "{{ istio_ip }}"
-#            podAnnotations:
-#              sidecar.istio.io/inject: "false"
-#
-#  - name: Istio deployment summary (step 23)
-#    debug:
-#      msg:
-#        - "Istio has been successfully installed using Helm."
-#        - "Your cluster is now prepared for Istio-based deployments."
+    become: false
+    shell: 'echo "y" | istioctl install -f /tmp/istio-config.yml'
+    changed_when: false
+    when: ansible_hostname == 'controller' and istio_system_ns_info.resources | length == 0
     
 #Assignment 3
 - import_playbook: monitoring-alerting.yml

--- a/provisioning/finalization.yml
+++ b/provisioning/finalization.yml
@@ -253,79 +253,123 @@
       kubectl taint nodes --all node-role.kubernetes.io/master:NoSchedule- || true
     changed_when: false
 
-  # ­­­­­­­­­­­­­­­­­STEP 23: Install Istio via Helm­­­­­­­­­­­­­­­­­
-  - name: Add Istio Helm repository (step 23)
-    kubernetes.core.helm_repository:
-      name: istio
-      repo_url: https://istio-release.storage.googleapis.com/charts
-      kubeconfig: "{{ kubeconfig }}"
+  # -----------------STEP 23: Install Istio-----------------
 
-  - name: Create namespace istio-system (step 23)
-    kubernetes.core.k8s:
-      kubeconfig: "{{ kubeconfig }}"
+  - name: Add Istio (step 23)
+    ansible.builtin.unarchive:
+      src: https://github.com/istio/istio/releases/download/1.25.2/istio-1.25.2-linux-arm64.tar.gz
+      dest: /usr/local/bin
+      remote_src: yes
+      mode: 'u=rX'
+
+  - name: Set user permissions for istioctl command (step 23)
+    ansible.builtin.file:
+      path: /usr/local/bin/istio-1.25.2
+      state: directory
+      recurse: yes
+      owner: vagrant
+      group: vagrant
+      mode: 'u=rX'
+
+  - name: Get contents of PATH (step 23)
+    command: cat /etc/environment
+    register: path_contents
+
+  - name: Add PATH line if it did not exist in /etc/environment (step 23)
+    ansible.builtin.lineinfile:
+      path: /etc/environment
+      line: 'PATH=""'
+      insertafter: EOF
       state: present
-      definition:
-        apiVersion: v1
-        kind: Namespace
-        metadata:
-          name: istio-system
+      create: true
+    when: not path_contents|regex_search('\s*PATH=.+')
 
-  - name: Install Istio base chart (CRDs) (step 23)
-    kubernetes.core.helm:
-      release_name: istio-base
-      chart_ref: istio/base
-      chart_version: "1.25.2"
-      release_namespace: istio-system
-      create_namespace: false
-      kubeconfig: "{{ kubeconfig }}"
-      wait: true
+  - name: Add istioctl to PATH (step 23)
+    ansible.builtin.lineinfile:
+      path: /etc/environment
+      regexp: "^PATH=(\"?)([^\"]+)(\"?)$"
+      line: 'PATH=\1\2:/usr/local/bin/istio-1.25.2/bin\3'
+      backrefs: yes
+    when: not path_contents|regex_search('istio-1.25.2')
 
-  - name: Install Istio control plane (istiod) (step 23)
-    kubernetes.core.helm:
-      release_name: istiod
-      chart_ref: istio/istiod
-      chart_version: "1.25.2"
-      release_namespace: istio-system
-      create_namespace: false
-      kubeconfig: "{{ kubeconfig }}"
-      wait: true
-      timeout: "300s"
-      values:
-        pilot:
-          resources:
-            # shrink requests so istiod can schedule on low‐RAM nodes (too heave otherwise, might need to be changed in the future)
-            requests:
-              cpu: "100m"
-              memory: "128Mi"
-            limits:
-              cpu: "200m"
-              memory: "256Mi"
+  - name: Prevent illegal format in PATH (step 23)
+    ansible.builtin.replace:
+      path: /etc/environment
+      regexp: "^PATH=(\"?):(.+)$"
+      replace: 'PATH=\1\2'
 
-  - name: Deploy Istio ingress gateway with fixed IP (step 23)
-    kubernetes.core.helm:
-      release_name: istio-ingress
-      chart_ref: istio/gateway
-      chart_version: "1.25.2"
-      release_namespace: istio-system
-      create_namespace: false
-      kubeconfig: "{{ kubeconfig }}"
-      wait: true
-      timeout: "300s"
-      values:
-        gateways:
-          istio-ingressgateway:
-            enabled: true
-            service:
-              type: LoadBalancer
-              loadBalancerIP: "{{ istio_ip }}"
-            podAnnotations:
-              sidecar.istio.io/inject: "false"
-
-  - name: Istio deployment summary (step 23)
-    debug:
-      msg:
-        - "Istio has been successfully installed using Helm."
-        - "Your cluster is now prepared for Istio-based deployments."
+#  - name: Add Istio Helm repository (step 23)
+#    kubernetes.core.helm_repository:
+#      name: istio
+#      repo_url: https://istio-release.storage.googleapis.com/charts
+#      kubeconfig: "{{ kubeconfig }}"
+#
+#  - name: Create namespace istio-system (step 23)
+#    kubernetes.core.k8s:
+#      kubeconfig: "{{ kubeconfig }}"
+#      state: present
+#      definition:
+#        apiVersion: v1
+#        kind: Namespace
+#        metadata:
+#          name: istio-system
+#
+#  - name: Install Istio base chart (CRDs) (step 23)
+#    kubernetes.core.helm:
+#      release_name: istio-base
+#      chart_ref: istio/base
+#      chart_version: "1.25.2"
+#      release_namespace: istio-system
+#      create_namespace: false
+#      kubeconfig: "{{ kubeconfig }}"
+#      wait: true
+#
+#  - name: Install Istio control plane (istiod) (step 23)
+#    kubernetes.core.helm:
+#      release_name: istiod
+#      chart_ref: istio/istiod
+#      chart_version: "1.25.2"
+#      release_namespace: istio-system
+#      create_namespace: false
+#      kubeconfig: "{{ kubeconfig }}"
+#      wait: true
+#      timeout: "300s"
+#      values:
+#        pilot:
+#          resources:
+#            # shrink requests so istiod can schedule on low‐RAM nodes (too heave otherwise, might need to be changed in the future)
+#            requests:
+#              cpu: "100m"
+#              memory: "128Mi"
+#            limits:
+#              cpu: "200m"
+#              memory: "256Mi"
+#
+#  - name: Deploy Istio ingress gateway with fixed IP (step 23)
+#    kubernetes.core.helm:
+#      release_name: istio-ingress
+#      chart_ref: istio/gateway
+#      chart_version: "1.25.2"
+#      release_namespace: istio-system
+#      create_namespace: false
+#      kubeconfig: "{{ kubeconfig }}"
+#      wait: true
+#      timeout: "300s"
+#      values:
+#        gateways:
+#          istio-ingressgateway:
+#            enabled: true
+#            service:
+#              type: LoadBalancer
+#              loadBalancerIP: "{{ istio_ip }}"
+#            podAnnotations:
+#              sidecar.istio.io/inject: "false"
+#
+#  - name: Istio deployment summary (step 23)
+#    debug:
+#      msg:
+#        - "Istio has been successfully installed using Helm."
+#        - "Your cluster is now prepared for Istio-based deployments."
     
 #Assignment 3
 - import_playbook: monitoring-alerting.yml

--- a/provisioning/finalization.yml
+++ b/provisioning/finalization.yml
@@ -282,21 +282,25 @@
       insertafter: EOF
       state: present
       create: true
-    when: not path_contents|regex_search('\s*PATH=.+')
+    when: not path_contents|regex_search('\s*PATH=.*')
 
   - name: Add istioctl to PATH (step 23)
     ansible.builtin.lineinfile:
       path: /etc/environment
-      regexp: "^PATH=(\"?)([^\"]+)(\"?)$"
+      regexp: "^PATH=(\"?)([^\"]*)(\"?)$"
       line: 'PATH=\1\2:/usr/local/bin/istio-1.25.2/bin\3'
       backrefs: yes
     when: not path_contents|regex_search('istio-1.25.2')
 
-  - name: Prevent illegal format in PATH (step 23)
-    ansible.builtin.replace:
-      path: /etc/environment
-      regexp: "^PATH=(\"?):(.+)$"
-      replace: 'PATH=\1\2'
+  - name: Copy Istio configuration file to node (step 23)
+    copy:
+      src: "{{ playbook_dir }}/istio-config.yml"
+      dest: /tmp/istio-config.yml
+      mode: '0644'
+
+  - name: Run istio installation on controller node (step 23)
+    command: istioctl install -f /tmp/istio-config.yml
+    when: ansible_hostname == 'controller'
 
 #  - name: Add Istio Helm repository (step 23)
 #    kubernetes.core.helm_repository:

--- a/provisioning/istio-config.yml
+++ b/provisioning/istio-config.yml
@@ -1,0 +1,13 @@
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+spec:
+  components:
+    pilot:
+      k8s:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 200m
+            memory: 256Mi


### PR DESCRIPTION
Step 23 in A2 describes installing Istio through `istioctl install`. This pull installs istioctl on the nodes, adds it to PATH, and uses that to set up Istio.

The gateway will be properly set up in https://github.com/remla25-team3/operation/pull/30 (A5).

#### Todo later

- [ ] Adjust istio installation based on VM architecture.