### PR TITLE
Add GitHub Actions workflow for releasing charts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.TEAM_APP_ID }}
+          private-key: ${{ secrets.TEAM_APP_KEY }}
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.7.0
+        env:
+          CR_TOKEN: "${{ steps.app-token.outputs.token }}"
+          charts_dir: "kubernetes/remla-app"


### PR DESCRIPTION
This uses gh-pages in order to publish helm charts on our GitHub repository. As our repository is public its now possible to helm install through internet instead of moving files over.