### PR TITLE
feat:Add asynchronicity to ctrl VM playbook

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,7 @@
+[defaults]
+host_key_checking = False   # we can do this because we are setting up VMs ourselves
+pipelining = True
+forks = 10
+
+[ssh_connection]
+ssh_args = -o ControlMaster=auto -o ControlPersist=180s

--- a/provisioning/ctrl.yml
+++ b/provisioning/ctrl.yml
@@ -2,6 +2,49 @@
   become: true
   tasks:
 
+  # --------- STEP 17: Install Helm Diff Plugin ---------
+  - name: Download and install helm-diff if not already present (step 17)
+    async: 120
+    poll: 0
+    register: install_helm_diff_async_task
+    ansible.builtin.command: >
+      helm plugin install https://github.com/databus23/helm-diff
+    args:
+      creates: /home/vagrant/.local/share/helm/plugins/helm-diff
+    become_user: vagrant
+    environment:
+      KUBECONFIG: ""
+      HELM_KUBECONFIG: ""
+
+  # --------- STEP 16: Install Helm ---------
+  - name: Define Helm install script URL and temporary path (step 16)
+    ansible.builtin.set_fact:
+      helm_script_url: "https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3"
+      helm_script_path: "/home/vagrant/get_helm.sh"
+
+  - name: Check if Helm binary exists (step 16)
+    ansible.builtin.stat:
+      path: /usr/local/bin/helm
+    register: helm_binary_stat
+
+  - name: Download Helm install script (step 16)
+    ansible.builtin.get_url:
+      url: "{{ helm_script_url }}"
+      dest: "{{ helm_script_path }}"
+      mode: '0755'
+    become: false
+    when: not helm_binary_stat.stat.exists
+
+  - name: Install Helm if not present (step 16)
+    async: 120
+    poll: 0
+    register: install_helm_async_task
+    ansible.builtin.command:
+      cmd: "{{ helm_script_path }}"
+      creates: /usr/local/bin/helm
+    become: true
+    when: not helm_binary_stat.stat.exists
+
   #download kubernetes library (needed for step 15)
   - name: Ensure Kubernetes Python client is installed
     apt:
@@ -144,6 +187,34 @@
       src: "{{ flannel_path }}"
       kubeconfig: /home/vagrant/.kube/config
 
+  - name: Retrieve async task job IDs that are still running
+    ansible.builtin.stat:
+      path: "/root/.ansible_async/{{ item }}"
+    loop:
+      - "{{ install_helm_async_task.ansible_job_id }}"
+      - "{{ install_helm_diff_async_task.ansible_job_id }}"
+    register: job_id_checks
+
+  - name: Filter existing job IDs
+    set_fact:
+      existing_job_ids: "{{ job_id_checks.results | selectattr('stat.exists', 'equalto', true) | map(attribute='item') | list }}"
+
+  - name: Wait for asynchronous tasks to complete
+    ansible.builtin.async_status:
+      jid: "{{ item.item }}"
+    loop:
+      - "{{ existing_job_ids }}"
+    register: async_tasks_result
+    until: async_tasks_result.finished
+    retries: 100
+    delay: 10
+
+  - name: Clean up Helm install script (step 16)
+    ansible.builtin.file:
+      path: "{{ helm_script_path }}"
+      state: absent
+    become: false
+
   - name:  Verify Flannel is running (step 15)
     ansible.builtin.shell: |
       kubectl --kubeconfig=/home/vagrant/.kube/config get pods -n kube-flannel -o custom-columns=STATUS:.status.phase --no-headers | grep -c "Running" | grep -q "^[1-9]"
@@ -153,46 +224,4 @@
     delay: 6
     changed_when: false
     ignore_errors: true
-
-  # --------- STEP 16: Install Helm ---------
-  - name: Define Helm install script URL and temporary path (step 16)
-    ansible.builtin.set_fact:
-      helm_script_url: "https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3"
-      helm_script_path: "/home/vagrant/get_helm.sh"
-
-  - name: Download Helm install script (step 16)
-    ansible.builtin.get_url:
-      url: "{{ helm_script_url }}"
-      dest: "{{ helm_script_path }}"
-      mode: '0755'
-    become: false
-
-  - name: Check if Helm binary exists (step 16)
-    ansible.builtin.stat:
-      path: /usr/local/bin/helm
-    register: helm_binary_stat
-
-  - name: Install Helm if not present (step 16)
-    ansible.builtin.command:
-      cmd: "{{ helm_script_path }}"
-      creates: /usr/local/bin/helm
-    become: true
-    when: not helm_binary_stat.stat.exists
-
-  - name: Clean up Helm install script (step 16)
-    ansible.builtin.file:
-      path: "{{ helm_script_path }}"
-      state: absent
-    become: false
-
-  # --------- STEP 17: Install Helm Diff Plugin ---------
-  - name: Download and install helm-diff if not already present (step 17)
-    ansible.builtin.command: >
-      helm plugin install https://github.com/databus23/helm-diff
-    args:
-      creates: /home/vagrant/.local/share/helm/plugins/helm-diff
-    become_user: vagrant
-    environment:
-      KUBECONFIG: ""
-      HELM_KUBECONFIG: ""
 

--- a/provisioning/ctrl.yml
+++ b/provisioning/ctrl.yml
@@ -2,20 +2,6 @@
   become: true
   tasks:
 
-  # --------- STEP 17: Install Helm Diff Plugin ---------
-  - name: Download and install helm-diff if not already present (step 17)
-    async: 120
-    poll: 0
-    register: install_helm_diff_async_task
-    ansible.builtin.command: >
-      helm plugin install https://github.com/databus23/helm-diff
-    args:
-      creates: /home/vagrant/.local/share/helm/plugins/helm-diff
-    become_user: vagrant
-    environment:
-      KUBECONFIG: ""
-      HELM_KUBECONFIG: ""
-
   # --------- STEP 16: Install Helm ---------
   - name: Define Helm install script URL and temporary path (step 16)
     ansible.builtin.set_fact:
@@ -187,27 +173,34 @@
       src: "{{ flannel_path }}"
       kubeconfig: /home/vagrant/.kube/config
 
-  - name: Retrieve async task job IDs that are still running
+  - name: Retrieve async task ID of helm installation task if it is still running
     ansible.builtin.stat:
-      path: "/root/.ansible_async/{{ item }}"
-    loop:
-      - "{{ install_helm_async_task.ansible_job_id }}"
-      - "{{ install_helm_diff_async_task.ansible_job_id }}"
-    register: job_id_checks
+      path: "/root/.ansible_async/{{ install_helm_async_task.ansible_job_id }}"
+    register: helm_job_id_check
 
-  - name: Filter existing job IDs
-    set_fact:
-      existing_job_ids: "{{ job_id_checks.results | selectattr('stat.exists', 'equalto', true) | map(attribute='item') | list }}"
-
-  - name: Wait for asynchronous tasks to complete
+  - name: Wait for helm installation async task to complete
     ansible.builtin.async_status:
-      jid: "{{ item.item }}"
-    loop:
-      - "{{ existing_job_ids }}"
-    register: async_tasks_result
-    until: async_tasks_result.finished
-    retries: 100
-    delay: 10
+      jid: "{{ install_helm_async_task.ansible_job_id }}"
+    when: helm_job_id_check.stat.exists
+    register: helm_async_task_result
+    until: helm_async_task_result.finished
+    retries: 60
+    delay: 1
+    ignore_errors: true
+
+  # --------- STEP 17: Install Helm Diff Plugin ---------
+  - name: Download and install helm-diff if not already present (step 17)
+    async: 120
+    poll: 0
+    register: install_helm_diff_async_task
+    ansible.builtin.command: >
+      helm plugin install https://github.com/databus23/helm-diff
+    args:
+      creates: /home/vagrant/.local/share/helm/plugins/helm-diff
+    become_user: vagrant
+    environment:
+      KUBECONFIG: ""
+      HELM_KUBECONFIG: ""
 
   - name: Clean up Helm install script (step 16)
     ansible.builtin.file:
@@ -215,13 +208,28 @@
       state: absent
     become: false
 
+  - name: Retrieve async task ID of helm diff installation task if it is still running
+    ansible.builtin.stat:
+      path: "/root/.ansible_async/{{ install_helm_diff_async_task.ansible_job_id }}"
+    register: helm_diff_job_id_check
+
+  - name: Wait for helm diff installation async task to complete
+    ansible.builtin.async_status:
+      jid: "{{ install_helm_diff_async_task.ansible_job_id }}"
+    when: helm_diff_job_id_check.stat.exists
+    register: helm_diff_async_task_result
+    until: helm_diff_async_task_result.finished
+    retries: 120
+    delay: 1
+    ignore_errors: true
+
   - name:  Verify Flannel is running (step 15)
     ansible.builtin.shell: |
       kubectl --kubeconfig=/home/vagrant/.kube/config get pods -n kube-flannel -o custom-columns=STATUS:.status.phase --no-headers | grep -c "Running" | grep -q "^[1-9]"
     register: flannel_check
     until: flannel_check.rc == 0
-    retries: 10
-    delay: 6
+    retries: 60
+    delay: 1
     changed_when: false
     ignore_errors: true
 


### PR DESCRIPTION
Making some tasks asynchronous in the `ctrl.yml` playbook appears to save about 20 to 25 seconds in provisioning.

Time saved heavily depends on the host system and internet connection.

Currently, `vagrant up` takes about 3m30s; applying `finalization.yml` subsequently takes another 3 to 4 minutes (on my MacBook Pro, M1, 16GB).

~~There is currently one error at the end when checking if the async tasks have completed:~~

~~`failed: [ctrl] (item=['j830128607442.3790']) => {"ansible_job_id": "['j830128607442.3790']", "ansible_loop_var": "item", "attempts": 1, "changed": false, "finished": 1, "item": ["j830128607442.3790"], "msg": "could not find job", "results_file": "/root/.ansible_async/['j830128607442.3790']", "started": 1, "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}`~~

~~This should be an easy fix though and will be picked up soon.~~